### PR TITLE
Strikethrough canceled goals in past matches

### DIFF
--- a/ui/match/match.go
+++ b/ui/match/match.go
@@ -27,6 +27,8 @@ var (
 			Background(lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FAFAFA"}).
 			Foreground(lipgloss.AdaptiveColor{Light: "#FAFAFA", Dark: "#000000"})
 
+	canceledEventStyle = lipgloss.NewStyle().Strikethrough(true)
+
 	shirtNumberStyle = lipgloss.NewStyle().Width(2)
 )
 
@@ -132,7 +134,14 @@ func renderEvents(events []data.Event, reverse bool) string {
 
 func renderEvent(event data.Event, reverse bool) string {
 	if reverse {
+		if event.Canceled {
+			return canceledEventStyle.Render(event.Player+" "+event.Minute) + " " + renderEventType(event.Type)
+		}
 		return event.Player + " " + event.Minute + " " + renderEventType(event.Type)
+	}
+
+	if event.Canceled {
+		return renderEventType(event.Type) + " " + canceledEventStyle.Render(event.Minute+" "+event.Player)
 	}
 	return renderEventType(event.Type) + " " + event.Minute + " " + event.Player
 }


### PR DESCRIPTION
Only for past matches since APIs do not return this info in live.

<img width="1728" alt="Screenshot 2022-12-03 at 3 04 42 PM" src="https://user-images.githubusercontent.com/1479924/205444875-be6b8075-b51f-445d-a822-a1a269ec8692.png">